### PR TITLE
Add validation/fixes for time formatting strings

### DIFF
--- a/generate-api/src/main.rs
+++ b/generate-api/src/main.rs
@@ -1,6 +1,7 @@
 pub mod generator;
 pub mod parser;
 
+use crate::parser::{Object, Value};
 use anyhow::{bail, Result};
 use cargo_metadata::MetadataCommand;
 use sha2::{Digest, Sha256};
@@ -32,7 +33,8 @@ fn main() -> Result<()> {
         let path = entry.path();
         if let Ok(input) = std::fs::read_to_string(&path) {
             eprintln!("{}", path.display());
-            let objects = parser::parse(&input)?;
+            let mut objects = parser::parse(&input)?;
+            validate_and_fix(&mut objects);
             locales.insert(lang.to_string(), objects);
         }
     }
@@ -65,4 +67,40 @@ fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn validate_and_fix(objects: &mut Vec<Object>) {
+    validate_and_fix_t_fmt_ampm(objects);
+}
+
+/// Add a `T_FMT_AMPM` item if it is missing (happens for 3 locales).
+///
+/// If the locale has non-empty values for `AM_PM` we assume the correct string to be the same as
+/// for POSIX: `%l:%M:%S %p`.
+/// If the locale has empty values for `AM_PM` we set `T_FMT_AMPM` to an empty value, similar to
+/// other locales that don't have a 12-hour clock format.
+fn validate_and_fix_t_fmt_ampm(objects: &mut Vec<Object>) {
+    for object in objects.iter_mut() {
+        if object.name != "LC_TIME" {
+            continue;
+        }
+        let mut found_t_fmt_ampm = false;
+        let mut am_pm_empty = false;
+        for (key, value) in object.values.iter() {
+            match (key.as_str(), value.as_slice()) {
+                ("t_fmt_ampm" | "copy" | "insert", _) => found_t_fmt_ampm = true,
+                ("am_pm", &[Value::String(ref am), Value::String(ref pm)]) => {
+                    am_pm_empty = am.is_empty() && pm.is_empty()
+                }
+                _ => {}
+            }
+        }
+        if !found_t_fmt_ampm {
+            let value = match am_pm_empty {
+                true => vec![Value::String(String::new())],
+                false => vec![Value::String("%l:%M:%S %p".to_string())],
+            };
+            object.values.push(("t_fmt_ampm".to_string(), value));
+        }
+    }
 }

--- a/generate-api/src/parser.rs
+++ b/generate-api/src/parser.rs
@@ -104,6 +104,7 @@ fn parse_str<'a, E: ParseError<&'a str>>(
         map_parser(
             alt((
                 take_while1(|c| c != escape_char && c != '"'),
+                map(preceded(char(escape_char), char('\n')), |_| ""),
                 preceded(char(escape_char), take(1_usize)),
             )),
             unescape_unicode,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9ccbfe512bb22a5bae98a7f827d7fa27c3f1c5303f9ab830077c172649e523f6
-size 1910482
+oid sha256:6c08876364b47b50780e370afd1edaaa366efced2f1865cb1e632116d53946ac
+size 1910700

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6c08876364b47b50780e370afd1edaaa366efced2f1865cb1e632116d53946ac
-size 1910700
+oid sha256:e574ef120aceb2af5dbe301a6170761b01230d3bd930358ed281e9ef403c8d2f
+size 1911312

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e574ef120aceb2af5dbe301a6170761b01230d3bd930358ed281e9ef403c8d2f
-size 1911312
+oid sha256:e15fdf95d7b2e46cb0656179221afec3e81a4e0434bb7f57cd0349c31ca73ee4
+size 1911096

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:13e522bf7f4507f95b8d8f0033d701fc74d57d8062ac3470c4762cb3e8e0ecab
-size 1910588
+oid sha256:9ccbfe512bb22a5bae98a7f827d7fa27c3f1c5303f9ab830077c172649e523f6
+size 1910482


### PR DESCRIPTION
In https://github.com/chronotope/chrono/pull/1058 in chrono we run into two issues.

Three locales are missing `T_FMT_AMPM` (`ff_SN`, `km_KH`, `ug_CN`). This makes us unable to use `locale_match!` for `T_FMT_AMPM`. We could hack around it, but it seems better to me to fix the locales.
If I look at the three cases, the ones that define `AMPM` should have `"%l:%M:%S %p"` and otherwise use `""`.

The other issue is more of a detail, but something I would appreciate.
Since https://github.com/chronotope/chrono/pull/1152 we try to parse a format string without allocating. For this we switch from parsing the user-supplied format string to a localized format string when it encounters `%x`, `%X` or `%c` (and hopefully soon on `%r`). 
The iterator is able to hold a reference to the original string, and to the localized string that is being parsed.

Now if the localized string references another localized string, such as `%r` inside `%c`, we would have to add the ability to switch to parsing a third format string.

It would be great `pure-rust-locales` could inline the format string of `%x`, `%X` and `%r` into `D_T_FMT`.
But if this is not an option, we can work around it.