### PR TITLE
Use Option to avoid failures in locale_match!

### DIFF
--- a/generate-api/src/generator.rs
+++ b/generate-api/src/generator.rs
@@ -1,342 +1,407 @@
-use crate::parser;
+use std::borrow::Cow;
+use std::collections::{BTreeMap, HashMap};
+use std::fmt::{Formatter, Write};
+
 use indenter::CodeFormatter;
 use itertools::Itertools;
-use std::collections::HashMap;
-use std::fmt;
-use std::fmt::Write;
 
-fn generate_object<W: Write>(
-    f: &mut CodeFormatter<W>,
-    object: &parser::Object,
-    locales: &HashMap<String, Vec<parser::Object>>,
-) -> fmt::Result {
-    for (key, group) in &object
-        .values
-        .iter()
-        .filter(|x| !x.1.is_empty())
-        .sorted_by(|a, b| Ord::cmp(&a.0, &b.0))
-        .group_by(|x| x.0.clone())
-    {
-        let key = key
-            .replace("'", "")
-            .replace("\"", "")
-            .replace("-", "_")
-            .replace("=", "eq")
-            .replace("<", "lt")
-            .replace("..", "dotdot")
-            .replace("2", "two")
-            .to_uppercase();
-        let group: Vec<_> = group.map(|x| &x.1).collect();
+use crate::parser;
 
-        if key == "copy" || key == "include" {
-            match &group[0][0] {
-                parser::Value::String(other_lang) => {
-                    let other = locales
-                        .get(other_lang)
-                        .unwrap_or_else(|| panic!("unknown locale: {}", other_lang));
-                    let other_object = other
-                        .iter()
-                        .find(|x| x.name == object.name)
-                        .expect("could not find object to copy from");
-                    generate_object(f, other_object, locales)?;
-                }
-                _ => panic!("only a string value is accepted for key \"copy\""),
-            }
-            continue;
-        }
+type Key = String;
+type Field = String;
+type Lang = String;
 
-        if group.len() == 1 && group[0].is_empty() {
-            return Ok(());
-        } else if group.len() == 1 && group[0].len() == 1 {
-            let singleton = &group[0][0];
-
-            match singleton {
-                parser::Value::Raw(x) | parser::Value::String(x) => write!(
-                    f,
-                    r#"
-                    /// `{x:?}`
-                    pub const {key}: &str = {x:?};
-                    "#,
-                    key = key,
-                    x = x
-                )?,
-                parser::Value::Integer(x) => write!(
-                    f,
-                    r#"
-                    /// `{x:?}`
-                    pub const {key}: i64 = {x:?};
-                    "#,
-                    key = key,
-                    x = x
-                )?,
-            }
-        } else if group.len() == 1 && group[0].iter().map(u8::from).all_equal() {
-            let values = &group[0];
-            let formatted = values.iter().map(|x| format!("{}", x)).join(", ");
-
-            match &values[0] {
-                parser::Value::Raw(_) | parser::Value::String(_) => write!(
-                    f,
-                    r#"
-                    /// `&[{x}]`
-                    pub const {key}: &[&str] = &[{x}];
-                    "#,
-                    key = key,
-                    x = formatted
-                )?,
-                parser::Value::Integer(_) => write!(
-                    f,
-                    r#"
-                    /// `&[{x}]`
-                    pub const {key}: &[i64] = &[{x}];
-                    "#,
-                    key = key,
-                    x = formatted
-                )?,
-            }
-        } else if group
-            .iter()
-            .map(|x| x.iter().map(u8::from))
-            .flatten()
-            .all_equal()
-        {
-            write!(
-                f,
-                r#"
-                /// ```ignore
-                /// &[
-                "#,
-            )?;
-
-            for values in group.iter() {
-                write!(
-                    f,
-                    r#"
-                    ///     &[{}],
-                    "#,
-                    values.iter().map(|x| format!("{}", x)).join(", "),
-                )?;
-            }
-
-            write!(
-                f,
-                r#"
-                /// ]
-                /// ```
-                "#,
-            )?;
-
-            match group[0][0] {
-                parser::Value::Raw(_) | parser::Value::String(_) => write!(
-                    f,
-                    r#"
-                    pub const {}: &[&[&str]] = &[
-                    "#,
-                    key
-                )?,
-                parser::Value::Integer(_) => write!(
-                    f,
-                    r#"
-                    pub const {}: &[&[i64]] = &[
-                    "#,
-                    key,
-                )?,
-            }
-            f.indent(1);
-
-            for values in group.iter() {
-                write!(
-                    f,
-                    r#"
-                    &[{}],
-                    "#,
-                    values.iter().map(|x| format!("{}", x)).join(", "),
-                )?;
-            }
-
-            f.dedent(1);
-            write!(
-                f,
-                r#"
-                ];
-                "#,
-            )?;
-        } else {
-            unimplemented!("mixed types");
-        }
-    }
-
-    Ok(())
+pub struct CodeGenerator {
+    by_language: BTreeMap<Lang, BTreeMap<Key, Category>>,
+    field_metadata: BTreeMap<Key, BTreeMap<Field, Meta>>,
+    normalized_langs: BTreeMap<Lang, String>,
 }
 
-fn generate_locale<W: Write>(
-    f: &mut CodeFormatter<W>,
-    lang_normalized: &str,
-    objects: &[parser::Object],
-    locales: &HashMap<String, Vec<parser::Object>>,
-) -> fmt::Result {
-    write!(
-        f,
-        r#"
+enum Category {
+    Link(String, String),
+    Fields(BTreeMap<Field, Value>),
+}
 
-        #[allow(non_snake_case,non_camel_case_types,dead_code,unused_imports)]
-        pub mod {} {{
-        "#,
-        lang_normalized,
-    )?;
-    f.indent(1);
+#[derive(Clone)]
+enum Value {
+    Empty,
+    Literal(String),
+    Array(Vec<String>),
+    Array2d(Vec<Vec<String>>),
+}
 
-    for object in objects.iter().sorted_by_key(|x| x.name.to_string()) {
-        if object.name == "LC_COLLATE"
-            || object.name == "LC_CTYPE"
-            || object.name == "LC_MEASUREMENT"
-            || object.name == "LC_PAPER"
-            || object.name == "LC_NAME"
-        {
-            continue;
-        } else if object.values.len() == 1 {
-            let (key, value) = &object.values[0];
-            #[allow(clippy::single_match)]
-            match key.as_str() {
-                "copy" => {
-                    assert_eq!(value.len(), 1);
-                    match &value[0] {
-                        parser::Value::String(x) => write!(
-                            f,
-                            r#"
-                            pub use super::{}::{};
-                            "#,
-                            x.replace("@", "_"),
-                            object.name,
-                        )?,
-                        x => panic!("unexpected value for key {}: {:?}", key, x),
+struct TypeFormatter<'a> {
+    meta: &'a Meta,
+}
+
+impl<'a> TypeFormatter<'a> {
+    fn new(meta: &'a Meta) -> Self {
+        Self { meta }
+    }
+}
+
+impl<'a> std::fmt::Display for TypeFormatter<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match &self.meta.ty {
+            None => unreachable!(),
+            Some(ty) => {
+                if self.meta.optional {
+                    match self.meta.container_ty {
+                        ContainerType::Singleton => write!(f, "Option<{}>", ty),
+                        ContainerType::Array => write!(f, "Option<&[{}]>", ty),
+                        ContainerType::Array2D => write!(f, "Option<&[&[{}]]>", ty),
+                    }
+                } else {
+                    match self.meta.container_ty {
+                        ContainerType::Singleton => write!(f, "{}", ty),
+                        ContainerType::Array => write!(f, "&[{}]", ty),
+                        ContainerType::Array2D => write!(f, "&[&[{}]]", ty),
                     }
                 }
-                _ => {}
             }
-        } else {
-            write!(
+        }
+    }
+}
+
+struct ValueFormatter<'a> {
+    value: &'a Value,
+    meta: &'a Meta,
+}
+
+impl<'a> ValueFormatter<'a> {
+    fn new(value: &'a Value, meta: &'a Meta) -> Self {
+        Self { value, meta }
+    }
+
+    fn format(f: &mut Formatter<'_>, value: &Value, ty: &Type) -> std::fmt::Result {
+        match value {
+            Value::Empty => unreachable!(),
+            Value::Literal(x) => write!(f, "{}", LiteralFormatter::new(x, ty),),
+            Value::Array(x) => write!(
                 f,
-                r#"
-                pub mod {} {{
-                "#,
-                object.name,
-            )?;
-            f.indent(1);
-            generate_object(f, &object, locales)?;
-            f.dedent(1);
-            write!(
-                f,
-                r#"
-                }}
-                "#,
-            )?;
+                "&[{val}]",
+                val = x
+                    .iter()
+                    .map(|x| format!("{}", LiteralFormatter::new(x, ty)))
+                    .join(", "),
+            ),
+            Value::Array2d(x) => {
+                write!(f, r#"&["#,)?;
+
+                for values in x.iter() {
+                    write!(
+                        f,
+                        r#"
+                &[{}],"#,
+                        values
+                            .iter()
+                            .map(|x| format!("{}", LiteralFormatter::new(x, ty)))
+                            .join(", "),
+                    )?;
+                }
+
+                write!(
+                    f,
+                    r#"
+            ]"#,
+                )?;
+
+                Ok(())
+            }
+        }
+    }
+}
+
+impl<'a> std::fmt::Display for ValueFormatter<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match &self.meta.ty {
+            None => unreachable!(),
+            Some(ty) => {
+                if self.meta.optional {
+                    match self.value {
+                        Value::Empty => write!(f, "None"),
+                        _ => {
+                            write!(f, "Some(")?;
+                            Self::format(f, self.value, ty)?;
+                            write!(f, ")")
+                        }
+                    }
+                } else {
+                    match self.value {
+                        Value::Empty => unreachable!(),
+                        _ => Self::format(f, self.value, ty),
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct LiteralFormatter<'a> {
+    value: &'a str,
+    ty: &'a Type,
+}
+
+impl<'a> LiteralFormatter<'a> {
+    fn new(value: &'a str, ty: &'a Type) -> Self {
+        Self { value, ty }
+    }
+}
+
+impl<'a> std::fmt::Display for LiteralFormatter<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self.ty {
+            Type::String => write!(f, "{:?}", self.value),
+            Type::Integer => write!(f, "{}", self.value),
+        }
+    }
+}
+
+impl Value {
+    fn with_fixed_type<'a>(&'a self, meta: &Meta) -> Cow<'a, Self> {
+        match meta.container_ty {
+            ContainerType::Singleton => match self {
+                Value::Empty | Value::Literal(_) => Cow::Borrowed(self),
+                Value::Array(_) => unreachable!(),
+                Value::Array2d(_) => unreachable!(),
+            },
+            ContainerType::Array => match self {
+                Value::Empty => Cow::Borrowed(self),
+                Value::Literal(x) => Cow::Owned(Value::Array(vec![x.clone()])),
+                Value::Array(_) => Cow::Borrowed(self),
+                Value::Array2d(_) => unreachable!(),
+            },
+            ContainerType::Array2D => match self {
+                Value::Empty => Cow::Borrowed(self),
+                Value::Literal(x) => Cow::Owned(Self::Array2d(vec![vec![x.clone()]])),
+                Value::Array(x) => Cow::Owned(Self::Array2d(vec![x.clone()])),
+                Value::Array2d(_) => Cow::Borrowed(self),
+            },
         }
     }
 
-    f.dedent(1);
-    write!(
-        f,
-        r#"
-        }}
-        "#,
-    )
+    fn generate<W: Write>(
+        &self,
+        field_name: &str,
+        meta: &Meta,
+        f: &mut CodeFormatter<W>,
+    ) -> std::fmt::Result {
+        let ty = meta.ty.as_ref().unwrap();
+        let type_formatter = TypeFormatter::new(meta);
+        let value_formatter = ValueFormatter::new(self, meta);
+
+        match self {
+            Value::Array2d(x) => {
+                write!(
+                    f,
+                    r#"
+                    /// ```ignore
+                    /// &[
+                    "#,
+                )?;
+
+                for values in x.iter() {
+                    write!(
+                        f,
+                        r#"
+                        ///     &[{}],
+                        "#,
+                        values
+                            .iter()
+                            .map(|x| format!("{}", LiteralFormatter::new(x, ty)))
+                            .join(", "),
+                    )?;
+                }
+
+                write!(
+                    f,
+                    r#"
+                    /// ]
+                    /// ```
+                    "#,
+                )?;
+            }
+            _ => {
+                write!(
+                    f,
+                    r#"
+                    /// `{val}`
+                    "#,
+                    val = value_formatter,
+                )?;
+            }
+        }
+
+        write!(
+            f,
+            r#"
+            pub const {key}: {ty} = {val};
+            "#,
+            key = field_name,
+            ty = type_formatter,
+            val = value_formatter,
+        )?;
+
+        Ok(())
+    }
 }
 
-fn generate_variants<W: Write>(f: &mut CodeFormatter<W>, langs: &[(&str, &str)]) -> fmt::Result {
-    write!(
-        f,
-        r#"
+impl CodeGenerator {
+    pub fn new(objects: HashMap<String, Vec<parser::Object>>) -> Self {
+        let mut by_language = BTreeMap::<Lang, BTreeMap<Key, Category>>::new();
+        let mut field_metadata = BTreeMap::<Key, BTreeMap<Field, Meta>>::new();
+        let mut normalized_langs = BTreeMap::<Lang, String>::new();
 
-        #[allow(non_camel_case_types,dead_code)]
-        #[derive(Debug, Copy, Clone, PartialEq)]
-        pub enum Locale {{
-        "#,
-    )?;
-    f.indent(1);
+        for (lang, objects) in objects.iter() {
+            normalized_langs.insert(lang.to_string(), lang.replace("@", "_"));
 
-    for (lang, norm) in langs {
-        write!(
-            f,
-            r#"
-            /// {lang}
-            {norm},
-            "#,
-            lang = lang,
-            norm = norm,
-        )?;
+            let lang_categories = by_language
+                .entry(lang.to_string())
+                .or_insert(BTreeMap::new());
+
+            for object in objects.iter() {
+                if object.name == "LC_COLLATE"
+                    || object.name == "LC_CTYPE"
+                    || object.name == "LC_MEASUREMENT"
+                    || object.name == "LC_PAPER"
+                    || object.name == "LC_NAME"
+                {
+                    continue;
+                } else if object.values.len() == 1 {
+                    let (key, value) = &object.values[0];
+                    #[allow(clippy::single_match)]
+                    match key.as_str() {
+                        "copy" => {
+                            assert_eq!(value.len(), 1);
+
+                            match &value[0] {
+                                parser::Value::String(x) => {
+                                    lang_categories.insert(
+                                        object.name.clone(),
+                                        Category::Link(x.replace("@", "_"), object.name.clone()),
+                                    );
+                                }
+                                x => panic!("unexpected value for key {}: {:?}", key, x),
+                            }
+                        }
+                        _ => {}
+                    }
+                    continue;
+                }
+
+                let mut fields = BTreeMap::<Field, Value>::new();
+
+                let cat_field_meta = field_metadata
+                    .entry(object.name.clone())
+                    .or_insert(BTreeMap::new());
+
+                for (key, group) in &object
+                    .values
+                    .iter()
+                    .filter(|x| !x.1.is_empty())
+                    .sorted_by(|a, b| Ord::cmp(&a.0, &b.0))
+                    .group_by(|x| x.0.clone())
+                {
+                    let key = key
+                        .replace("'", "")
+                        .replace("\"", "")
+                        .replace("-", "_")
+                        .replace("=", "eq")
+                        .replace("<", "lt")
+                        .replace("..", "dotdot")
+                        .replace("2", "two")
+                        .to_uppercase();
+                    let group: Vec<_> = group.map(|x| &x.1).collect();
+
+                    let meta = cat_field_meta.entry(key.clone()).or_insert(Meta::new());
+
+                    if group.len() == 1 && group[0].is_empty() {
+                        meta.make_optional();
+                        fields.insert(key, Value::Empty);
+                    } else if group.len() == 1 && group[0].len() == 1 {
+                        let singleton = &group[0][0];
+
+                        match singleton {
+                            parser::Value::Raw(_) | parser::Value::String(_) => meta.mark_str(),
+                            parser::Value::Integer(_) => meta.mark_int(),
+                        }
+
+                        fields.insert(key, Value::Literal(singleton.to_string()));
+                    } else if group.len() == 1 && group[0].iter().map(u8::from).all_equal() {
+                        let values = &group[0];
+                        let vec = values.iter().map(|x| x.to_string()).collect::<Vec<_>>();
+
+                        meta.mark_array();
+
+                        match &values[0] {
+                            parser::Value::Raw(_) | parser::Value::String(_) => meta.mark_str(),
+                            parser::Value::Integer(_) => meta.mark_int(),
+                        }
+
+                        fields.insert(key, Value::Array(vec));
+                    } else if group
+                        .iter()
+                        .map(|x| x.iter().map(u8::from))
+                        .flatten()
+                        .all_equal()
+                    {
+                        meta.mark_array_2d();
+
+                        let mut vec = Vec::with_capacity(group.len());
+
+                        for a in group.iter() {
+                            for value in a.iter() {
+                                match value {
+                                    parser::Value::Raw(_) | parser::Value::String(_) => {
+                                        meta.mark_str()
+                                    }
+                                    parser::Value::Integer(_) => meta.mark_int(),
+                                }
+                            }
+
+                            let inner_vec = a.iter().map(|x| x.to_string()).collect::<Vec<_>>();
+
+                            vec.push(inner_vec);
+                        }
+
+                        fields.insert(key, Value::Array2d(vec));
+                    } else {
+                        unimplemented!()
+                    }
+                }
+
+                lang_categories.insert(object.name.clone(), Category::Fields(fields));
+            }
+        }
+
+        for (_lang, categories) in by_language.iter_mut() {
+            for (category_name, all_fields) in field_metadata.iter_mut() {
+                let language_cats = categories
+                    .entry(category_name.clone())
+                    .or_insert(Category::Fields(BTreeMap::new()));
+
+                match language_cats {
+                    Category::Link(_, _) => {}
+                    Category::Fields(fields) => {
+                        for (field, meta) in all_fields {
+                            if let None = fields.get(field) {
+                                fields.insert(field.clone(), Value::Empty);
+                                meta.make_optional();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Self {
+            by_language,
+            field_metadata,
+            normalized_langs,
+        }
     }
 
-    f.dedent(1);
-    write!(
-        f,
-        r#"
-        }}
-
-        impl core::convert::TryFrom<&str> for Locale {{
-            type Error = UnknownLocale;
-
-            fn try_from(i: &str) -> Result<Self, Self::Error> {{
-                match i {{
-        "#,
-    )?;
-    f.indent(3);
-
-    for (lang, norm) in langs {
-        write!(
-            f,
-            r#"
-            {lang:?} => Ok(Locale::{norm}),
-            "#,
-            lang = lang,
-            norm = norm,
-        )?;
-    }
-
-    f.dedent(3);
-    write!(
-        f,
-        r#"
-                    _ => Err(UnknownLocale),
-                }}
-            }}
-        }}
-
-        #[macro_export]
-        macro_rules! locale_match {{
-            ($locale:expr => $($item:ident)::+) => {{{{
-                match $locale {{
-        "#,
-    )?;
-    f.indent(3);
-
-    for (_, norm) in langs {
-        write!(
-            f,
-            r#"
-            $crate::Locale::{norm} => $crate::{norm}::$($item)::+,
-            "#,
-            norm = norm,
-        )?;
-    }
-    f.dedent(3);
-
-    write!(
-        f,
-        r#"
-                }}
-            }}}}
-        }}
-
-        "#,
-    )
-}
-
-pub struct CodeGenerator(pub HashMap<String, Vec<parser::Object>>);
-
-impl fmt::Display for CodeGenerator {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut f = CodeFormatter::new(f, "    ");
+    fn generate<W: Write>(&self, f: &mut CodeFormatter<W>) -> std::fmt::Result {
         write!(
             f,
             r#"
@@ -348,24 +413,254 @@ impl fmt::Display for CodeGenerator {
             "#,
         )?;
 
-        let locales = &self.0;
+        for (lang, categories) in self.by_language.iter() {
+            let lang = &self.normalized_langs[lang];
 
-        let normalized: HashMap<_, _> = locales
-            .iter()
-            .map(|(lang, _)| (lang, lang.replace("@", "_")))
-            .collect();
+            write!(
+                f,
+                r#"
 
-        let mut sorted: Vec<_> = locales.iter().collect();
-        sorted.sort_unstable_by_key(|(lang, _)| lang.to_string());
-        for (lang, objects) in sorted.iter() {
-            generate_locale(&mut f, normalized[lang].as_str(), &objects, locales)?;
+                #[allow(non_snake_case,non_camel_case_types,dead_code,unused_imports)]
+                pub mod {} {{
+                "#,
+                lang,
+            )?;
+            f.indent(1);
+
+            for (category_name, category) in categories.iter() {
+                let category_metadata = self.field_metadata.get(category_name).unwrap();
+
+                match category {
+                    Category::Link(lang, category_name) => {
+                        write!(
+                            f,
+                            r#"
+                            pub use super::{}::{};
+                            "#,
+                            lang, category_name,
+                        )?;
+                    }
+                    Category::Fields(fields) => {
+                        write!(
+                            f,
+                            r#"
+                            pub mod {} {{
+                            "#,
+                            category_name,
+                        )?;
+
+                        f.indent(1);
+
+                        for (field_name, meta) in category_metadata.iter() {
+                            fields
+                                .get(field_name)
+                                .unwrap()
+                                .with_fixed_type(meta)
+                                .generate(field_name, meta, f)?;
+                        }
+
+                        f.dedent(1);
+
+                        write!(
+                            f,
+                            r#"
+                            }}
+                            "#,
+                        )?;
+                    }
+                }
+            }
+
+            f.dedent(1);
+
+            write!(
+                f,
+                r#"
+                }}
+                "#,
+            )?
         }
 
-        let mut sorted: Vec<_> = locales
-            .iter()
-            .map(|(lang, _)| (lang.as_str(), normalized[lang].as_str()))
-            .collect();
-        sorted.sort_unstable_by_key(|(lang, _)| lang.to_string());
-        generate_variants(&mut f, &sorted)
+        self.generate_variants(f)?;
+
+        Ok(())
+    }
+
+    fn generate_variants<W: Write>(&self, f: &mut CodeFormatter<W>) -> std::fmt::Result {
+        write!(
+            f,
+            r#"
+
+            #[allow(non_camel_case_types,dead_code)]
+            #[derive(Debug, Copy, Clone, PartialEq)]
+            pub enum Locale {{
+            "#,
+        )?;
+        f.indent(1);
+
+        for (lang, norm) in self.normalized_langs.iter() {
+            write!(
+                f,
+                r#"
+                /// {lang}
+                {norm},
+                "#,
+                lang = lang,
+                norm = norm,
+            )?;
+        }
+
+        f.dedent(1);
+        write!(
+            f,
+            r#"
+            }}
+
+            impl core::convert::TryFrom<&str> for Locale {{
+                type Error = UnknownLocale;
+
+                fn try_from(i: &str) -> Result<Self, Self::Error> {{
+                    match i {{
+            "#,
+        )?;
+        f.indent(3);
+
+        for (lang, norm) in self.normalized_langs.iter() {
+            write!(
+                f,
+                r#"
+                {lang:?} => Ok(Locale::{norm}),
+                "#,
+                lang = lang,
+                norm = norm,
+            )?;
+        }
+
+        f.dedent(3);
+        write!(
+            f,
+            r#"
+                        _ => Err(UnknownLocale),
+                    }}
+                }}
+            }}
+
+            #[macro_export]
+            macro_rules! locale_match {{
+                ($locale:expr => $($item:ident)::+) => {{{{
+                    match $locale {{
+            "#,
+        )?;
+        f.indent(3);
+
+        for (_, norm) in self.normalized_langs.iter() {
+            write!(
+                f,
+                r#"
+                $crate::Locale::{norm} => $crate::{norm}::$($item)::+,
+                "#,
+                norm = norm,
+            )?;
+        }
+        f.dedent(3);
+
+        write!(
+            f,
+            r#"
+                    }}
+                }}}}
+            }}
+
+            "#,
+        )
+    }
+}
+
+impl std::fmt::Display for CodeGenerator {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut f = CodeFormatter::new(f, "    ");
+        self.generate(&mut f)
+    }
+}
+
+struct Meta {
+    optional: bool,
+    container_ty: ContainerType,
+    ty: Option<Type>,
+}
+
+impl Meta {
+    fn new() -> Self {
+        Self {
+            optional: false,
+            container_ty: ContainerType::Singleton,
+            ty: None,
+        }
+    }
+
+    fn mark_str(&mut self) {
+        self.ty = match self.ty {
+            Some(Type::Integer) => Some(Type::String),
+            Some(Type::String) => Some(Type::String),
+            None => Some(Type::String),
+        }
+    }
+
+    fn mark_int(&mut self) {
+        self.ty = match self.ty {
+            Some(Type::Integer) => Some(Type::Integer),
+            Some(Type::String) => Some(Type::String),
+            None => Some(Type::Integer),
+        }
+    }
+
+    fn make_optional(&mut self) {
+        self.optional = true;
+    }
+
+    fn mark_array(&mut self) {
+        self.container_ty = self.container_ty.into_array();
+    }
+
+    fn mark_array_2d(&mut self) {
+        self.container_ty = self.container_ty.into_array_2d();
+    }
+}
+
+#[derive(Copy, Clone)]
+pub enum ContainerType {
+    Singleton,
+    Array,
+    Array2D,
+}
+
+pub enum Type {
+    String,
+    Integer,
+}
+
+impl std::fmt::Display for Type {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Type::String => f.write_str("&str"),
+            Type::Integer => f.write_str("i64"),
+        }
+    }
+}
+
+impl ContainerType {
+    fn into_array(self) -> Self {
+        match self {
+            Self::Singleton => Self::Array,
+            _ => self,
+        }
+    }
+
+    fn into_array_2d(self) -> Self {
+        match self {
+            Self::Singleton => Self::Array2D,
+            Self::Array => Self::Array2D,
+            _ => self,
+        }
     }
 }

--- a/generate-api/src/main.rs
+++ b/generate-api/src/main.rs
@@ -45,7 +45,7 @@ fn main() -> Result<()> {
         eprintln!("Calculating checksum...");
         let mut f = Sha256::default();
 
-        write!(f, "{}", generator::CodeGenerator(locales))?;
+        write!(f, "{}", generator::CodeGenerator::new(locales))?;
 
         let expected = f.finalize();
         eprintln!("expected: {:x}", expected);
@@ -63,7 +63,7 @@ fn main() -> Result<()> {
     } else {
         eprintln!("Writing to file `{}`...", lib_file.display());
         let mut f = BufWriter::new(fs::File::create(&lib_file)?);
-        write!(f, "{}", generator::CodeGenerator(locales))?;
+        write!(f, "{}", generator::CodeGenerator::new(locales))?;
     }
 
     Ok(())

--- a/generate-api/src/parser.rs
+++ b/generate-api/src/parser.rs
@@ -32,7 +32,7 @@ impl From<&Value> for u8 {
 impl std::fmt::Display for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Value::Raw(x) | Value::String(x) => write!(f, "{:?}", x),
+            Value::Raw(x) | Value::String(x) => write!(f, "{}", x), // FIXME
             Value::Integer(x) => write!(f, "{:?}", x),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e15fdf95d7b2e46cb0656179221afec3e81a4e0434bb7f57cd0349c31ca73ee4
-size 1911096
+oid sha256:c451e9c365e52627a23c0f7c601b42fac56b198cbd5081422805ef1e76483595
+size 2446433

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -2,7 +2,12 @@ use std::convert::TryInto;
 
 #[test]
 fn locale_match() {
+    use pure_rust_locales::locale_match;
+
     let locale = "fr_BE".try_into().unwrap();
-    let result = pure_rust_locales::locale_match!(locale => LC_TIME::D_FMT);
-    assert_eq!(result, "%d/%m/%y");
+
+    assert_eq!(locale_match!(locale => LC_TIME::D_FMT), "%d/%m/%y");
+    assert_eq!(locale_match!(locale => LC_NUMERIC::DECIMAL_POINT), ",");
+    assert_eq!(locale_match!(locale => LC_NUMERIC::GROUPING), &[3, 3]);
+    assert_eq!(locale_match!(locale => LC_NUMERIC::THOUSANDS_SEP), ".");
 }

--- a/tests/simple_test.rs
+++ b/tests/simple_test.rs
@@ -5,7 +5,7 @@ fn it_works() {
     use pure_rust_locales::fr_BE;
 
     assert_eq!(fr_BE::LC_TIME::D_FMT, "%d/%m/%y");
-    assert_eq!(fr_BE::LC_TIME::FIRST_WEEKDAY, 2_i64);
+    assert_eq!(fr_BE::LC_TIME::FIRST_WEEKDAY, Some(2_i64));
 }
 
 #[test]


### PR DESCRIPTION
This change adds postprocessing of parsed constants to determine if values are present in all locales (optional), or ensures that the types are always the same. For example, if a value was previously registerd as `i64` for one locale _and_ a `String` for another, it will now always be a `String`.

Similarly, when certain values are present in some locales but not others, the types will be wrapped in `Option`.

When a whole module is missing, a dummy one will be created with all `const`s set to `None`.

All of this should fix the compilation errors when trying to use `locale_match!` with locales that previously had diverging types.

This is most likely _not_ a backwards compatible change, still, I'm going to double check that nothing breaks in `chrono`.

Closes #4.